### PR TITLE
88 feature request allow user to save bet and defacing masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@
 
 This includes **normalization**, **co-registration**, **atlas registration** and **skulstripping / brain extraction**.
 
-BrainLes is written `backend-agnostic` meaning it allows to swap the registration and brain extraction tools.
-
-<!-- TODO mention defacing -->
+BrainLes is written `backend-agnostic` meaning it allows to swap the registration, brain extraction tools and defacing tools.
 
 <!-- TODO include image here -->
 
@@ -32,7 +30,7 @@ pip install brainles-preprocessing
 A minimal example to register (to the standard atlas using ANTs) and skull strip (using HDBet) a t1c image (center modality) with 1 moving modality (flair) could look like this:
 ```python
 from pathlib import Path
-from brainles_preprocessing.modality import Modality
+from brainles_preprocessing.modality import Modality, CenterModality
 from brainles_preprocessing.normalization.percentile_normalizer import (
     PercentileNormalizer,
 )
@@ -48,8 +46,8 @@ percentile_normalizer = PercentileNormalizer(
     upper_limit=1,
 )
 
-# define modalities
-center = Modality(
+# define center and moving modalities
+center = CenterModality(
     modality_name="t1c",
     input_path=patient_folder / "t1c.nii.gz",
     normalizer=percentile_normalizer,

--- a/brainles_preprocessing/modality.py
+++ b/brainles_preprocessing/modality.py
@@ -1,5 +1,6 @@
 import logging
 import shutil
+import warnings
 from pathlib import Path
 from typing import Optional, Union
 
@@ -346,6 +347,8 @@ class Modality:
         bet_dir_path: Union[str, Path],
     ) -> Path:
         """
+        WARNING: Legacy method. Please Migrate to use the CenterModality Class. Will be removed in future versions.
+
         Extract the brain region using the specified brain extractor.
 
         Args:
@@ -355,6 +358,13 @@ class Modality:
         Returns:
             Path: Path to the extracted brain mask.
         """
+
+        warnings.warn(
+            "Legacy method. Please Migrate to use the CenterModality Class. Will be removed in future versions.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
+
         bet_dir_path = Path(bet_dir_path)
         bet_log = bet_dir_path / "brain-extraction.log"
 
@@ -382,6 +392,8 @@ class Modality:
         defaced_dir_path: Union[str, Path],
     ) -> Path:
         """
+        WARNING: Legacy method. Please Migrate to use the CenterModality Class. Will be removed in future versions.
+
         Deface the current modality using the specified defacer.
 
         Args:
@@ -391,7 +403,11 @@ class Modality:
         Returns:
             Path: Path to the extracted brain mask.
         """
-
+        warnings.warn(
+            "Legacy method. Please Migrate to use the CenterModality class. Will be removed in future versions.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
         if isinstance(defacer, QuickshearDefacer):
 
             defaced_dir_path = Path(defaced_dir_path)
@@ -443,3 +459,134 @@ class Modality:
                 src=str(self.current),
                 dst=str(output_path),
             )
+
+
+class CenterModality(Modality):
+
+    def __init__(
+        self,
+        modality_name: str,
+        input_path: Union[str, Path],
+        normalizer: Optional[Normalizer] = None,
+        raw_bet_output_path: Optional[Union[str, Path]] = None,
+        raw_skull_output_path: Optional[Union[str, Path]] = None,
+        raw_defaced_output_path: Optional[Union[str, Path]] = None,
+        normalized_bet_output_path: Optional[Union[str, Path]] = None,
+        normalized_skull_output_path: Optional[Union[str, Path]] = None,
+        normalized_defaced_output_path: Optional[Union[str, Path]] = None,
+        atlas_correction: bool = True,
+        bet_mask_output: Optional[Union[str, Path]] = None,
+        deface_mask_output: Optional[Union[str, Path]] = None,
+    ) -> None:
+        super().__init__(
+            modality_name=modality_name,
+            input_path=input_path,
+            normalizer=normalizer,
+            raw_bet_output_path=raw_bet_output_path,
+            raw_skull_output_path=raw_skull_output_path,
+            raw_defaced_output_path=raw_defaced_output_path,
+            normalized_bet_output_path=normalized_bet_output_path,
+            normalized_skull_output_path=normalized_skull_output_path,
+            normalized_defaced_output_path=normalized_defaced_output_path,
+            atlas_correction=atlas_correction,
+        )
+        # Only for CenterModality
+        self.bet_mask_output = Path(bet_mask_output) if bet_mask_output else None
+        self.deface_mask_output = (
+            Path(deface_mask_output) if deface_mask_output else None
+        )
+
+    def extract_brain_region(
+        self,
+        brain_extractor: BrainExtractor,
+        bet_dir_path: Union[str, Path],
+    ) -> Path:
+        """
+        Extract the brain region using the specified brain extractor.
+
+        Args:
+            brain_extractor (BrainExtractor): The brain extractor object.
+            bet_dir_path (str or Path): Directory to store brain extraction results.
+
+        Returns:
+            Path: Path to the extracted brain mask.
+        """
+        bet_dir_path = Path(bet_dir_path)
+        bet_log = bet_dir_path / "brain-extraction.log"
+
+        atlas_bet_cm = bet_dir_path / f"atlas__{self.modality_name}_bet.nii.gz"
+        mask_path = bet_dir_path / f"atlas__{self.modality_name}_brain_mask.nii.gz"
+
+        brain_extractor.extract(
+            input_image_path=self.current,
+            masked_image_path=atlas_bet_cm,
+            brain_mask_path=mask_path,
+            log_file_path=bet_log,
+        )
+
+        if self.bet_mask_output:
+            logger.debug(f"Saving bet mask to {self.bet_mask_output}")
+            self.save_mask(mask_path=mask_path, output_path=self.bet_mask_output)
+
+        # always temporarily store bet image for center modality, since e.g. quickshear defacing could require it
+        # down the line even if the user does not wish to save the bet image
+        self.steps[PreprocessorSteps.BET] = atlas_bet_cm
+
+        if self.bet:
+            self.current = atlas_bet_cm
+        return mask_path
+
+    def deface(
+        self,
+        defacer,
+        defaced_dir_path: Union[str, Path],
+    ) -> Path:
+        """
+        Deface the current modality using the specified defacer.
+
+        Args:
+            defacer (Defacer): The defacer object.
+            defaced_dir_path (str or Path): Directory to store defacing results.
+
+        Returns:
+            Path: Path to the extracted brain mask.
+        """
+
+        if isinstance(defacer, QuickshearDefacer):
+
+            defaced_dir_path = Path(defaced_dir_path)
+            atlas_mask_path = (
+                defaced_dir_path / f"atlas__{self.modality_name}_deface_mask.nii.gz"
+            )
+
+            defacer.deface(
+                mask_image_path=atlas_mask_path,
+                input_image_path=self.steps[PreprocessorSteps.BET],
+            )
+
+            if self.deface_mask_output:
+                logger.debug(f"Saving deface mask to {self.deface_mask_output}")
+                self.save_mask(
+                    mask_path=atlas_mask_path, output_path=self.deface_mask_output
+                )
+
+            return atlas_mask_path
+        else:
+            logger.warning(
+                "Defacing method not implemented yet. Skipping defacing for this modality."
+            )
+            return None
+
+    def save_mask(self, mask_path: Union[str, Path], output_path: Path) -> None:
+        """
+        Save the mask to the specified output path.
+
+        Args:
+            mask_path (Union[str, Path]): Mask NifTI file path.
+            output_path (Path): Output NifTI file path.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(
+            src=str(mask_path),
+            dst=str(output_path),
+        )

--- a/brainles_preprocessing/modality.py
+++ b/brainles_preprocessing/modality.py
@@ -361,8 +361,7 @@ class Modality:
 
         warnings.warn(
             "Legacy method. Please Migrate to use the CenterModality Class. Will be removed in future versions.",
-            category=FutureWarning,
-            stacklevel=2,
+            category=DeprecationWarning,
         )
 
         bet_dir_path = Path(bet_dir_path)
@@ -405,8 +404,7 @@ class Modality:
         """
         warnings.warn(
             "Legacy method. Please Migrate to use the CenterModality class. Will be removed in future versions.",
-            category=FutureWarning,
-            stacklevel=2,
+            category=DeprecationWarning,
         )
         if isinstance(defacer, QuickshearDefacer):
 

--- a/brainles_preprocessing/preprocessor.py
+++ b/brainles_preprocessing/preprocessor.py
@@ -10,12 +10,13 @@ from datetime import datetime
 from functools import wraps
 from pathlib import Path
 from typing import List, Optional, Union
+import warnings
 
 from brainles_preprocessing.constants import PreprocessorSteps
 from brainles_preprocessing.defacing import Defacer, QuickshearDefacer
 
 from .brain_extraction.brain_extractor import BrainExtractor, HDBetExtractor
-from .modality import Modality
+from .modality import Modality, CenterModality
 from .registration import ANTsRegistrator
 from .registration.registrator import Registrator
 
@@ -30,7 +31,7 @@ class Preprocessor:
     Preprocesses medical image modalities using coregistration, normalization, brain extraction, and more.
 
     Args:
-        center_modality (Modality): The central modality for coregistration.
+        center_modality (CenterModality): The central modality for coregistration.
         moving_modalities (List[Modality]): List of modalities to be coregistered to the central modality.
         registrator (Registrator): The registrator object for coregistration and registration to the atlas.
         brain_extractor (Optional[BrainExtractor]): The brain extractor object for brain extraction.
@@ -44,7 +45,7 @@ class Preprocessor:
 
     def __init__(
         self,
-        center_modality: Modality,
+        center_modality: CenterModality,
         moving_modalities: List[Modality],
         registrator: Registrator = None,
         brain_extractor: Optional[BrainExtractor] = None,
@@ -56,6 +57,14 @@ class Preprocessor:
     ):
         logging_man._setup_logger()
 
+        if not isinstance(center_modality, CenterModality):
+            warnings.warn(
+                "Center modality should be of type CenterModality instead of Modality to allow for more features, e.g. saving bet and deface masks. "
+                "Support for using Modality for the Center Modality will be deprecated in future versions. "
+                "Note: Moving modalities should still be of type Modality.",
+                category=FutureWarning,
+                stacklevel=2,
+            )
         self.center_modality = center_modality
         self.moving_modalities = moving_modalities
 

--- a/brainles_preprocessing/preprocessor.py
+++ b/brainles_preprocessing/preprocessor.py
@@ -62,8 +62,7 @@ class Preprocessor:
                 "Center modality should be of type CenterModality instead of Modality to allow for more features, e.g. saving bet and deface masks. "
                 "Support for using Modality for the Center Modality will be deprecated in future versions. "
                 "Note: Moving modalities should still be of type Modality.",
-                category=FutureWarning,
-                stacklevel=2,
+                category=DeprecationWarning,
             )
         self.center_modality = center_modality
         self.moving_modalities = moving_modalities


### PR DESCRIPTION
- Introduce `Modality` sub class `CenterModality` 
  - allows to specify optional output paths for bet/deface masks
  - implements extract brain region and deface methods previously located in the parent class (these methods now have deprecation warnings in the parent class and will be removed in future versions)

- updated readme example