### PR TITLE
153 bug defaultvalue for padding when registering without skull stripping seems to be off

### DIFF
--- a/brainles_preprocessing/registration/ANTs/ANTs.py
+++ b/brainles_preprocessing/registration/ANTs/ANTs.py
@@ -153,6 +153,7 @@ class ANTsRegistrator(Registrator):
     ) -> None:
         """
         Apply a transformation using ANTs.
+        By default the padding value corresponds to the minimum of the moving image. Can be adjusted using the defaultvalue parameter.
 
         Args:
             fixed_image_path (str or Path): Path to the fixed image.

--- a/brainles_preprocessing/registration/niftyreg/niftyreg.py
+++ b/brainles_preprocessing/registration/niftyreg/niftyreg.py
@@ -8,6 +8,7 @@ from typing import List
 import numpy as np
 from auxiliary.runscript import ScriptRunner
 from auxiliary.turbopath import turbopath
+from auxiliary.io import read_image
 
 from brainles_preprocessing.registration.registrator import Registrator
 
@@ -79,12 +80,16 @@ class NiftyRegRegistrator(Registrator):
 
         matrix_path = Path(matrix_path).with_suffix(".txt")
 
+        # read moving image to get padding value
+        padding_value = float(read_image(moving_image_path).min())
+
         input_params = [
             turbopath(niftyreg_executable),
             turbopath(fixed_image_path),
             turbopath(moving_image_path),
             turbopath(transformed_image_path),
             str(matrix_path),
+            str(padding_value),
         ]
 
         # Call the run method to execute the script and capture the output in the log file
@@ -199,13 +204,17 @@ class NiftyRegRegistrator(Registrator):
         else:
             transform_path = Path(matrix_path).with_suffix(".txt")
 
+        # read moving image to get padding value
+        padding_value = float(read_image(moving_image_path).min())
+
         input_params = [
             turbopath(niftyreg_executable),
             turbopath(fixed_image_path),
             turbopath(moving_image_path),
             turbopath(transformed_image_path),
             str(transform_path),
-            interpolator,  # interpolation method, 3 is Cubic
+            str(interpolator),  # interpolation method, 3 is Cubic
+            str(padding_value),
         ]
 
         # Call the run method to execute the script and capture the output in the log file

--- a/brainles_preprocessing/registration/niftyreg/niftyreg.py
+++ b/brainles_preprocessing/registration/niftyreg/niftyreg.py
@@ -160,6 +160,7 @@ class NiftyRegRegistrator(Registrator):
     ) -> None:
         """
         Apply a transformation using NiftyReg.
+        By default the padding value corresponds to the minimum of the moving image.
 
         Args:
             fixed_image_path (str): Path to the fixed image.

--- a/brainles_preprocessing/registration/niftyreg/niftyreg_scripts/rigid_reg.sh
+++ b/brainles_preprocessing/registration/niftyreg/niftyreg_scripts/rigid_reg.sh
@@ -10,8 +10,8 @@ file_exists() {
 }
 
 # Check if the correct number of arguments is provided
-if [ "$#" -ne 5 ]; then
-    echo "Usage: $0 <niftyreg_executable> <fixed_image> <moving_image> <transformed_image> <transformation_matrix>"
+if [ "$#" -ne 6 ]; then
+    echo "Usage: $0 <niftyreg_executable> <fixed_image> <moving_image> <transformed_image> <transformation_matrix> <padding_value>"
     exit 1
 fi
 
@@ -21,6 +21,7 @@ fixed_image="$2"
 moving_image="$3"
 transformed_image="$4"
 transformation_matrix="$5"
+padding_value="$6"
 
 # Validate the existence of input files
 if ! file_exists "$fixed_image"; then
@@ -41,6 +42,7 @@ registration_options=(
     "-flo" "$moving_image"
     "-res" "$transformed_image"
     "-aff" "$transformation_matrix"
+    "-pad" "$padding_value"
 )
 
 # Perform rigid-only registration with NiftyReg

--- a/brainles_preprocessing/registration/niftyreg/niftyreg_scripts/transform.sh
+++ b/brainles_preprocessing/registration/niftyreg/niftyreg_scripts/transform.sh
@@ -10,8 +10,8 @@ file_exists() {
 }
 
 # Check if the correct number of arguments is provided
-if [ "$#" -ne 6 ]; then
-    echo "Usage: $0 <niftyreg_executable> <fixed_image> <moving_image> <transformed_image> <transformation_matrix> <interpolation_method>"
+if [ "$#" -ne 7 ]; then
+    echo "Usage: $0 <niftyreg_executable> <fixed_image> <moving_image> <transformed_image> <transformation_matrix> <interpolation_method> <padding_value>"
     exit 1
 fi
 
@@ -22,6 +22,7 @@ moving_image="$3"
 transformed_image="$4"
 transformation_matrix="$5"
 interpolation_method="$6"
+padding_value="$7"
 
 # Validate the existence of input files
 if ! file_exists "$fixed_image"; then
@@ -51,6 +52,7 @@ resample_command=(
     -trans "$transformation_matrix"
     -res "$transformed_image"
     -inter "$interpolation_method"
+    -pad "$padding_value"
 )
 
 if file_exists "$niftyreg_path"; then


### PR DESCRIPTION
The issue arises when the registrations lead to out-of-view voxels that will be filled with a default value (by default, 0). However, if the image is not normalised, 0 does not correspond to the background channel, leading to artefacts.
As a solution, we set the default padding value to the minimum of the moving image - this seems to fix the issue. We will have to monitor if this causes issues elsewhere.

As of now, this fix is only implemented for ANTs and niftyreg.