### PR TITLE
Fix quickshear edge detection wrap-around issue by using convolution

### DIFF
--- a/brainles_preprocessing/defacing/quickshear/nipy_quickshear.py
+++ b/brainles_preprocessing/defacing/quickshear/nipy_quickshear.py
@@ -84,10 +84,8 @@ def edge_mask(mask):
     brain = mask.any(axis=0)
 
     # Simple edge detection
-    kernel = np.array([[0, -1, 0],
-                       [-1, 4, -1],
-                       [0, -1, 0]])
-    edgemask = (convolve(brain, kernel, mode='constant', cval=0.0) != 0)
+    kernel = np.array([[0, -1, 0], [-1, 4, -1], [0, -1, 0]])
+    edgemask = convolve(brain, kernel, mode="constant", cval=0.0) != 0
 
     return edgemask.astype("uint8")
 

--- a/brainles_preprocessing/defacing/quickshear/nipy_quickshear.py
+++ b/brainles_preprocessing/defacing/quickshear/nipy_quickshear.py
@@ -11,6 +11,7 @@ import sys
 import nibabel as nb
 import numpy as np
 from numpy.typing import NDArray
+from scipy.ndimage import convolve
 
 try:
     from duecredit import BibTeX, due
@@ -83,14 +84,11 @@ def edge_mask(mask):
     brain = mask.any(axis=0)
 
     # Simple edge detection
-    edgemask = (
-        4 * brain
-        - np.roll(brain, 1, 0)
-        - np.roll(brain, -1, 0)
-        - np.roll(brain, 1, 1)
-        - np.roll(brain, -1, 1)
-        != 0
-    )
+    kernel = np.array([[0, -1, 0],
+                       [-1, 4, -1],
+                       [0, -1, 0]])
+    edgemask = (convolve(brain, kernel, mode='constant', cval=0.0) != 0)
+
     return edgemask.astype("uint8")
 
 

--- a/brainles_preprocessing/registration/__init__.py
+++ b/brainles_preprocessing/registration/__init__.py
@@ -1,6 +1,5 @@
 import warnings
 
-
 try:
     from .ANTs.ANTs import ANTsRegistrator
 except ImportError:
@@ -10,7 +9,6 @@ except ImportError:
 
 
 from .niftyreg.niftyreg import NiftyRegRegistrator
-
 
 try:
     from .elastix.elastix import ElastixRegistrator


### PR DESCRIPTION
Bug fix for the edge detection wrap-around issue mentioned in #167:
- `np.roll` operations are changed to `scipy.ndimage.convolve` with a 4-neighborhood Laplacian edge detection kernel. 
- Tested over various real and synthetic brain masks, and outputs are found to be identical to baseline for brain-not-touching-edge cases. 
- SciPY already in project dependencies.
- Runtime and peak memory usage are benchmarked against baseline and another solution (`np.pad` before `np.roll`). Summarized results are as below.
  <img width="930" height="1074" alt="image" src="https://github.com/user-attachments/assets/8cf336a8-ab98-4634-b508-1fdda30aa7ad" />