### PR TITLE
Changed workflow for setting the masking value in the skull stripping

### DIFF
--- a/brainles_preprocessing/brain_extraction/brain_extractor.py
+++ b/brainles_preprocessing/brain_extraction/brain_extractor.py
@@ -29,7 +29,7 @@ class BrainExtractor(ABC):
         # Just as in the defacer, masking value is a global value defined across all images and modalities
         # If no value is passed, the minimum of a given input image is chosen
         # TODO: Consider extending this to modality-specific masking values in the future, this should
-        # probably be implemented as a property of the the specific modality
+        # probably be implemented as a property of the specific modality
         self.masking_value = masking_value
 
     @abstractmethod

--- a/brainles_preprocessing/brain_extraction/brain_extractor.py
+++ b/brainles_preprocessing/brain_extraction/brain_extractor.py
@@ -8,11 +8,6 @@ import numpy as np
 from auxiliary.io import read_image, write_image
 
 
-class Mode(Enum):
-    FAST = "fast"
-    ACCURATE = "accurate"
-
-
 class BrainExtractor(ABC):
     def __init__(
         self,
@@ -45,7 +40,6 @@ class BrainExtractor(ABC):
             input_image_path (str or Path): Path to the input image.
             masked_image_path (str or Path): Path where the brain-extracted image will be saved.
             brain_mask_path (str or Path): Path where the brain mask will be saved.
-            mode (str or Mode): Extraction mode.
             **kwargs: Additional keyword arguments.
         """
         pass

--- a/brainles_preprocessing/brain_extraction/brain_extractor.py
+++ b/brainles_preprocessing/brain_extraction/brain_extractor.py
@@ -30,7 +30,6 @@ class BrainExtractor(ABC):
         # probably be implemented as a property of the specific modality
         self.masking_value = masking_value
 
-class BrainExtractor(ABC):
     @abstractmethod
     def extract(
         self,
@@ -102,74 +101,3 @@ class BrainExtractor(ABC):
             raise RuntimeError(f"Error writing output file: {e}") from e
 
 
-class HDBetExtractor(BrainExtractor):
-    def __init__(self, masking_value: Optional[Union[int, float]] = None):
-        """
-        Brain extraction HDBet implementation.
-
-        Args:
-            masking_value (Optional[Union[int, float]], optional): global value to be inserted in the masked areas. Default is None which leads to the minimum of each respective image.
-        """
-        super().__init__(masking_value=masking_value)
-
-    def extract(
-        self,
-        input_image_path: Union[str, Path],
-        masked_image_path: Union[str, Path],
-        brain_mask_path: Union[str, Path],
-        mode: Union[str, Mode] = Mode.ACCURATE,
-        device: Optional[Union[int, str]] = 0,
-        do_tta: bool = True,
-        **kwargs,
-    ) -> None:
-        # GPU + accurate + TTA
-        """
-        Skull-strips images with HD-BET and generates a skull-stripped file and mask.
-
-        Args:
-            input_image_path (str or Path): Path to the input image.
-            masked_image_path (str or Path): Path where the brain-extracted image will be saved.
-            brain_mask_path (str or Path): Path where the brain mask will be saved.
-            mode (str or Mode): Extraction mode ('fast' or 'accurate').
-            device (str or int): Device to use for computation (e.g., 0 for GPU 0, 'cpu' for CPU).
-            do_tta (bool): whether to do test time data augmentation by mirroring along all axes.
-        """
-
-        # Ensure mode is a Mode enum instance
-        if isinstance(mode, str):
-            try:
-                mode_enum = Mode(mode.lower())
-            except ValueError:
-                raise ValueError(f"'{mode}' is not a valid Mode.")
-        elif isinstance(mode, Mode):
-            mode_enum = mode
-        else:
-            raise TypeError("Mode must be a string or a Mode enum instance.")
-
-        # Run HD-BET
-        run_hd_bet(
-            mri_fnames=[str(input_image_path)],
-            output_fnames=[str(masked_image_path)],
-            mode=mode_enum.value,
-            device=device,
-            # TODO consider postprocessing
-            postprocess=False,
-            do_tta=do_tta,
-            keep_mask=True,
-            overwrite=True,
-        )
-
-        # Construct the path to the generated mask
-        masked_image_path = Path(masked_image_path)
-        hdbet_mask_path = masked_image_path.with_name(
-            masked_image_path.name.replace(".nii.gz", "_mask.nii.gz")
-        )
-
-        if hdbet_mask_path.resolve() != Path(brain_mask_path).resolve():
-            try:
-                shutil.copyfile(
-                    src=str(hdbet_mask_path),
-                    dst=str(brain_mask_path),
-                )
-            except Exception as e:
-                raise RuntimeError(f"Error copying mask file: {e}") from e

--- a/brainles_preprocessing/brain_extraction/brain_extractor.py
+++ b/brainles_preprocessing/brain_extraction/brain_extractor.py
@@ -99,5 +99,3 @@ class BrainExtractor(ABC):
             )
         except Exception as e:
             raise RuntimeError(f"Error writing output file: {e}") from e
-
-

--- a/brainles_preprocessing/brain_extraction/brain_extractor.py
+++ b/brainles_preprocessing/brain_extraction/brain_extractor.py
@@ -2,7 +2,6 @@
 from abc import abstractmethod, ABC
 from pathlib import Path
 from typing import Optional, Union
-from enum import Enum
 import numpy as np
 
 from auxiliary.io import read_image, write_image

--- a/brainles_preprocessing/brain_extraction/hd_bet.py
+++ b/brainles_preprocessing/brain_extraction/hd_bet.py
@@ -13,6 +13,15 @@ class Mode(Enum):
 
 
 class HDBetExtractor(BrainExtractor):
+    def __init__(self, masking_value: Optional[Union[int, float]] = None):
+        """
+        Brain extraction HDBet implementation.
+
+        Args:
+            masking_value (Optional[Union[int, float]], optional): global value to be inserted in the masked areas. Default is None which leads to the minimum of each respective image.
+        """
+        super().__init__(masking_value=masking_value)
+
     def extract(
         self,
         input_image_path: Union[str, Path],
@@ -74,3 +83,5 @@ class HDBetExtractor(BrainExtractor):
                 )
             except Exception as e:
                 raise RuntimeError(f"Error copying mask file: {e}") from e
+
+

--- a/brainles_preprocessing/brain_extraction/hd_bet.py
+++ b/brainles_preprocessing/brain_extraction/hd_bet.py
@@ -83,5 +83,3 @@ class HDBetExtractor(BrainExtractor):
                 )
             except Exception as e:
                 raise RuntimeError(f"Error copying mask file: {e}") from e
-
-

--- a/brainles_preprocessing/brain_extraction/synthstrip.py
+++ b/brainles_preprocessing/brain_extraction/synthstrip.py
@@ -21,7 +21,9 @@ from brainles_preprocessing.utils.zenodo import fetch_synthstrip
 
 class SynthStripExtractor(BrainExtractor):
 
-    def __init__(self, border: int = 1):
+    def __init__(
+        self, border: int = 1, masking_value: Optional[Union[int, float]] = None
+    ):
         """
         Brain extraction using SynthStrip with preprocessing conforming to model requirements.
 
@@ -31,9 +33,10 @@ class SynthStripExtractor(BrainExtractor):
 
         Args:
             border (int): Mask border threshold in mm. Defaults to 1.
-        """
+            masking_value (Optional[Union[int, float]], optional): global value to be inserted in the masked areas. Default is None which leads to the minimum of each respective image.
 
-        super().__init__()
+        """
+        super().__init__(masking_value=masking_value)
         self.border = border
 
     def _setup_model(self, device: torch.device) -> StripModel:

--- a/brainles_preprocessing/brain_extraction/synthstrip.py
+++ b/brainles_preprocessing/brain_extraction/synthstrip.py
@@ -222,8 +222,14 @@ class SynthStripExtractor(BrainExtractor):
 
         # write the masked output
         img_data = image.get_fdata()
-        bg = np.min([0, img_data.min()])
-        img_data[mask == 0] = bg
+        # check whether a global masking value was passed, otherwise choose minimum
+        if self.masking_value is None:
+            current_masking_value = np.min(img_data)
+        else:
+            current_masking_value = (
+                np.array(self.masking_value).astype(img_data.dtype).item()
+            )
+        img_data[mask == 0] = current_masking_value
         Nifti1Image(img_data, image.affine, image.header).to_filename(
             masked_image_path,
         )

--- a/brainles_preprocessing/registration/__init__.py
+++ b/brainles_preprocessing/registration/__init__.py
@@ -1,6 +1,5 @@
 import warnings
 
-
 try:
     from .ANTs.ANTs import ANTsRegistrator
 except ImportError:
@@ -10,7 +9,6 @@ except ImportError:
 
 
 from .niftyreg.niftyreg import NiftyRegRegistrator
-
 
 try:
     from .elastix.elastix import ElastixRegistrator


### PR DESCRIPTION
This change implements the the same process as in the defacing step to either use a global custom value for all inputs or the minimum value within the input image as the background value when masking an inage