### PR TITLE
Fix TypeError thrown when specifying interpolator for ANTsRegistrator

### DIFF
--- a/brainles_preprocessing/registration/ANTs/ANTs.py
+++ b/brainles_preprocessing/registration/ANTs/ANTs.py
@@ -172,7 +172,7 @@ class ANTsRegistrator(Registrator):
         # TODO - self.transformation_params
         # we update the transformation parameters with the provided kwargs
         transform_kwargs = {**self.transformation_params, **kwargs}
-        interpolator = transform_kwargs.pop('interpolator', interpolator)
+        interpolator = transform_kwargs.pop("interpolator", interpolator)
 
         assert interpolator in VALID_INTERPOLATORS, (
             f"Invalid interpolator: {interpolator}. "

--- a/brainles_preprocessing/registration/ANTs/ANTs.py
+++ b/brainles_preprocessing/registration/ANTs/ANTs.py
@@ -169,14 +169,15 @@ class ANTsRegistrator(Registrator):
         """
         start_time = datetime.datetime.now()
 
+        # TODO - self.transformation_params
+        # we update the transformation parameters with the provided kwargs
+        transform_kwargs = {**self.transformation_params, **kwargs}
+        interpolator = transform_kwargs.pop('interpolator', interpolator)
+
         assert interpolator in VALID_INTERPOLATORS, (
             f"Invalid interpolator: {interpolator}. "
             f"Valid options are: {', '.join(VALID_INTERPOLATORS)}."
         )
-
-        # TODO - self.transformation_params
-        # we update the transformation parameters with the provided kwargs
-        transform_kwargs = {**self.transformation_params, **kwargs}
 
         # Convert all paths to Path objects
         fixed_image_path = Path(fixed_image_path)


### PR DESCRIPTION
`interpolator` was passed twice to `ants.transform` when it was specified as an additional argument in
`ANTsRegistrator(transformation_params={'interpolator': 'value'})`. This change makes sure to pass it only once, and that the specified value takes precedence over the default. Fixes #177