### PR TITLE
fix: use P-axis length for ys calculation and clip S-axis bounds (#167)

### DIFF
--- a/brainles_preprocessing/defacing/quickshear/nipy_quickshear.py
+++ b/brainles_preprocessing/defacing/quickshear/nipy_quickshear.py
@@ -155,11 +155,12 @@ def run_quickshear(bet_img: nb.nifti1.Nifti1Image, buffer: int = 10) -> NDArray:
     slope = ydiffs[0] / xdiffs[0]
 
     yint = low[1][0] - (low[0][0] * slope) - buffer
-    ys = np.arange(0, mask_RPS.shape[2]) * slope + yint
+    ys = np.arange(0, mask_RPS.shape[1]) * slope + yint
     defaced_mask_RPS = np.ones(mask_RPS.shape, dtype="bool")
 
     for x, y in zip(np.nonzero(ys > 0)[0], ys.astype(int)):
-        defaced_mask_RPS[:, x, :y] = 0
+        y_clipped = min(y, mask_RPS.shape[2])
+        defaced_mask_RPS[:, x, :y_clipped] = 0
 
     defaced_mask = nb.orientations.apply_orientation(defaced_mask_RPS, from_RPS)
 


### PR DESCRIPTION
## Summary

Fixes the **second part of #167**: incorrect `ys` axis calculation and missing bounds clipping in QuickShear defacing.

### Root Cause

The `ys` calculation in `run_quickshear()` used `mask_RPS.shape[2]` (S-axis length) instead of `mask_RPS.shape[1]` (P-axis length):

```python
# Before (buggy)
ys = np.arange(0, mask_RPS.shape[2]) * slope + yint
```

In RPS orientation, the defacing loop iterates over **P-axis positions** (axis 1) and computes **S-axis limits** (axis 2) for each. Using `shape[2]` caused:
1. **Incorrect defacing masks** for images with narrow S axes (e.g., shape `(666, 512, 30)`) — the loop only iterated over 30 positions instead of 512
2. **IndexError** when computed S-axis limits exceeded `shape[2]` bounds (`defaced_mask_RPS[:, x, :y]` where `y > shape[2]`)

### Fix

```python
# After (fixed)
ys = np.arange(0, mask_RPS.shape[1]) * slope + yint
# ...
for x, y in zip(np.nonzero(ys > 0)[0], ys.astype(int)):
    y_clipped = min(y, mask_RPS.shape[2])  # prevent out-of-range
    defaced_mask_RPS[:, x, :y_clipped] = 0
```

### Verification

Tested with 4 scenarios including the exact shapes from the bug report:
- Normal brain mask (centered) ✓
- Brain touching P-axis boundary ✓  
- Narrow S-axis (`shape[2]=5`) ✓
- Large P-axis / narrow S-axis (`512 × 180`) — the IndexError case ✓

All tests pass with no IndexError and correct defacing behavior.

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
