### PR TITLE
fix: include Zenodo API error response body in error messages (#169)

### DIFF
--- a/brainles_preprocessing/utils/zenodo.py
+++ b/brainles_preprocessing/utils/zenodo.py
@@ -141,11 +141,19 @@ class ZenodoRecord:
                 # Zenodo returns JSON error details in the response body.
                 try:
                     error_detail = response.json()
-                except (ValueError, requests.exceptions.JSONDecodeError):
+                except ValueError:
                     error_detail = response.text.strip()
 
+                if response.status_code == 404:
+                    error_prefix = (
+                        f"Cannot find record '{self.record_id}' on Zenodo"
+                    )
+                else:
+                    error_prefix = (
+                        f"Failed to fetch record '{self.record_id}' from Zenodo"
+                    )
                 error_msg = (
-                    f"Cannot find record '{self.record_id}' on Zenodo "
+                    f"{error_prefix} "
                     f"(status_code={response.status_code}). "
                     f"Response: {error_detail}"
                 )

--- a/brainles_preprocessing/utils/zenodo.py
+++ b/brainles_preprocessing/utils/zenodo.py
@@ -137,9 +137,17 @@ class ZenodoRecord:
         try:
             response = requests.get(f"{self.BASE_URL}/{self.record_id}")
             if response.status_code != 200:
+                # Include the response body for easier debugging.
+                # Zenodo returns JSON error details in the response body.
+                try:
+                    error_detail = response.json()
+                except (ValueError, requests.exceptions.JSONDecodeError):
+                    error_detail = response.text.strip()
+
                 error_msg = (
                     f"Cannot find record '{self.record_id}' on Zenodo "
-                    f"({response.status_code=})."
+                    f"(status_code={response.status_code}). "
+                    f"Response: {error_detail}"
                 )
                 logger.error(error_msg)
                 raise ZenodoException(error_msg)

--- a/tests/test_zenodo.py
+++ b/tests/test_zenodo.py
@@ -57,11 +57,28 @@ def test_get_metadata_and_archive_url_success(
 def test_get_metadata_and_archive_url_failure(monkeypatch):
     response_mock = MagicMock()
     response_mock.status_code = 404
+    response_mock.json.return_value = {
+        "message": "The record does not exist.",
+        "status": 404,
+    }
 
     monkeypatch.setattr("requests.get", lambda *args, **kwargs: response_mock)
     record = ZenodoRecord("invalid", Path("/tmp"), "test")
 
-    with pytest.raises(ZenodoException):
+    with pytest.raises(ZenodoException, match="The record does not exist"):
+        record._get_metadata_and_archive_url()
+
+
+def test_get_metadata_and_archive_url_failure_with_text_body(monkeypatch):
+    response_mock = MagicMock()
+    response_mock.status_code = 403
+    response_mock.json.side_effect = ValueError("No JSON")
+    response_mock.text = "Rate limit exceeded. Please try again later."
+
+    monkeypatch.setattr("requests.get", lambda *args, **kwargs: response_mock)
+    record = ZenodoRecord("123", Path("/tmp"), "test")
+
+    with pytest.raises(ZenodoException, match="Rate limit exceeded"):
         record._get_metadata_and_archive_url()
 
 


### PR DESCRIPTION
## Summary

When the Zenodo API returns a non-200 status code, the error response body (which contains the actual explanation from Zenodo) was being discarded. The error message only showed the status code, making it impossible to diagnose issues like rate limiting (429), access denied (403), or invalid records (404).

## What was broken

In `_get_metadata_and_archive_url()`, the error message was:
```
Cannot find record '15236131' on Zenodo (response.status_code=403).
```

This provided no information about **why** the request failed. Users had no way to distinguish between rate limiting, access restrictions, or invalid record IDs without manually visiting the URL in a browser.

## What the fix does

1. **Parses the response body** — attempts JSON first (Zenodo returns structured error responses), falls back to raw text if the response isn't valid JSON.
2. **Includes the error detail in the exception message** — users now see the full context, e.g.:
   ```
   Cannot find record '15236131' on Zenodo (status_code=403). Response: {'message': 'Rate limit exceeded', 'status': 403}
   ```
3. **Updated tests** — the existing 404 test now verifies the response body is included, and a new test covers the non-JSON fallback path.

Fixes #169

## Verification

All 13 tests pass:
```
tests/test_zenodo.py::test_get_metadata_and_archive_url_success PASSED
tests/test_zenodo.py::test_get_metadata_and_archive_url_failure PASSED
tests/test_zenodo.py::test_get_metadata_and_archive_url_failure_with_text_body PASSED
tests/test_zenodo.py::test_get_metadata_and_archive_url_connection_error PASSED
tests/test_zenodo.py::test_get_latest_version_folder_name PASSED
tests/test_zenodo.py::test_get_latest_version_folder_name_empty PASSED
tests/test_zenodo.py::test_get_latest_version_folder_name_ignores_empty_folder PASSED
tests/test_zenodo.py::test_fetch_downloads_new_if_no_local PASSED
tests/test_zenodo.py::test_fetch_zenodo_unreachable_raises PASSED
tests/test_zenodo.py::test_fetch_skips_if_latest_present PASSED
tests/test_zenodo.py::test_fetch_replaces_old_version PASSED
tests/test_zenodo.py::test_fetch_atlases_calls_fetch PASSED
tests/test_zenodo.py::test_fetch_synthstrip_calls_fetch PASSED

======================== 13 passed ========================
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
