### PR TITLE
Fix CLI output directory type

### DIFF
--- a/brainles_preprocessing/cli.py
+++ b/brainles_preprocessing/cli.py
@@ -59,7 +59,7 @@ def main(
         ),
     ],
     output_dir: Annotated[
-        str | Path,
+        str,
         typer.Option(
             "-o",
             "--output_dir",

--- a/brainles_preprocessing/cli.py
+++ b/brainles_preprocessing/cli.py
@@ -59,11 +59,15 @@ def main(
         ),
     ],
     output_dir: Annotated[
-        str,
+        Path,
         typer.Option(
             "-o",
             "--output_dir",
             help="The path to the output directory",
+            exists=False,
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True,
         ),
     ],
     input_atlas: Annotated[
@@ -89,7 +93,6 @@ def main(
     Preprocess the input images according to the BraTS protocol.
     """
 
-    output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # specify a normalizer


### PR DESCRIPTION
## Summary

Restore the CLI-facing `output_dir` annotation from `str | Path` to `str`. Typer 0.15 does not support union-typed command parameters and currently raises `AssertionError: Typer Currently doesn't support Union types` while constructing the command, including for `preprocessor --help`.

The function already converts the value with `output_dir = Path(output_dir)`, so runtime path handling is unchanged.

## Neurodesk confirmation

This investigation was started with OpenAI Codex CLI while debugging the NeuroContainers BrainLesion image, then confirmed by Neurodesk release CI:

- The NeuroContainers [`Preprocessor CLI renders help` fulltest](https://github.com/neurodesk/neurocontainers/blob/main/recipes/brainlesion/fulltest.yaml#L251-L257) executes the installed console entry point.
- The unmodified upstream package [failed that test](https://github.com/neurodesk/neurocontainers/pull/2954#issuecomment-5090650552): 78/79 container checks passed, with `preprocessor --help` as the sole failure.
- NeuroContainers temporarily applied the same annotation correction in [neurodesk/neurocontainers#2955](https://github.com/neurodesk/neurocontainers/pull/2955).
- The replacement image then [passed all 79/79 checks](https://github.com/neurodesk/neurocontainers/pull/2956#issuecomment-5091685596), including `preprocessor --help`.

## Local validation

Tested from this branch under Python 3.10 with the project dependency set and Typer 0.15.4:

- `preprocessor --help`
- `preprocessor --version`

Both commands exit successfully.