### PR TITLE
chore: relax numpy constraint to allow >=2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ classifiers = [
 python = "^3.10"
 # core
 ttictoc = "^0.5.6"
-nibabel = ">=3.2.1"
-numpy = "^1.23.0"
+nibabel = ">=5.0.0"
+numpy = ">=1.23.0"
 typer = "^0.15.0"
 simpleitk = ">=2.2.1"
 


### PR DESCRIPTION
Closes #186

### Changes
- Relax `numpy` from `^1.23.0` → `>=1.23.0` to allow numpy 2.x
- Tighten `nibabel` from `>=3.2.1` → `>=5.0.0` (numpy 2.0 support added in nibabel 5.0.0)

### Rationale
All transitive dependencies already support numpy 2.x. See #186 for the full compatibility matrix. No code changes needed — the codebase uses only stable numpy APIs.